### PR TITLE
Fix: Update less.js URL to fix hex menu loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 	<title>Hexagonal Menu</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<link rel="stylesheet/less" href="style.less" type="text/css">
-	<script src="https://rawgithub.com/less/less.js/master/dist/less-1.4.1.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/less.js/4.2.2/less.min.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
The hex menu was not loading because the `less.js` script, which processes the `style.less` file, was referenced from `rawgithub.com`. This domain is no longer active, resulting in a 404 error for the script.

This commit updates the `less.js` script URL in `index.html` to a working CDN link from cdnjs.com (`https://cdnjs.cloudflare.com/ajax/libs/less.js/4.2.2/less.min.js`). This should allow the styles to be processed correctly and the hex menu to render as intended.